### PR TITLE
Bump version to 1.0.7

### DIFF
--- a/dist/rules/sort-keys-annotation.js
+++ b/dist/rules/sort-keys-annotation.js
@@ -142,6 +142,32 @@ exports.default = (0, createRule_1.createRule)({
                     });
                 }
             },
+            TSEnumDeclaration(node) {
+                const commentExpectedEndLine = node.loc.start.line - 1;
+                const config = config_1.ConfigUtils.getConfig(sourceCode, '@sort-keys', commentExpectedEndLine);
+                if (!config) {
+                    return;
+                }
+                const { isReversed } = config;
+                const comparer = comparer_1.ComparerUtils.makeEnumMemberComparer({ isReversed });
+                const members = node.members;
+                const sortedMembers = [...members].sort(comparer);
+                const needSort = array_1.ArrayUtils.zip2(members, sortedMembers).some(([member, sortedMember]) => member !== sortedMember);
+                if (needSort) {
+                    const diffRanges = array_1.ArrayUtils.zip2(members, sortedMembers).map(([from, to]) => ({
+                        from: from.range,
+                        to: to.range,
+                    }));
+                    const fixedText = fix_1.FixUtils.getFixedText(sourceCode, node.range, diffRanges);
+                    context.report({
+                        node,
+                        messageId: exports.HAS_UNSORTED_KEYS_MESSAGE_ID,
+                        fix(fixer) {
+                            return fixer.replaceTextRange(node.range, fixedText);
+                        },
+                    });
+                }
+            },
         };
     },
 });

--- a/dist/utils/comparer.js
+++ b/dist/utils/comparer.js
@@ -22,6 +22,24 @@ const compareProperty = (l, r) => {
         const rKey = r.key.name;
         return lKey === rKey ? 0 : lKey < rKey ? -1 : 1;
     }
+    else if (l.key.type === utils_1.AST_NODE_TYPES.MemberExpression &&
+        r.key.type === utils_1.AST_NODE_TYPES.MemberExpression &&
+        l.key.object.type === utils_1.AST_NODE_TYPES.Identifier &&
+        r.key.object.type === utils_1.AST_NODE_TYPES.Identifier &&
+        (l.key.property.type === utils_1.AST_NODE_TYPES.Identifier || l.key.property.type === utils_1.AST_NODE_TYPES.PrivateIdentifier) &&
+        (r.key.property.type === utils_1.AST_NODE_TYPES.Identifier || r.key.property.type === utils_1.AST_NODE_TYPES.PrivateIdentifier)) {
+        if (l.computed !== r.computed) {
+            return l.computed ? 1 : -1;
+        }
+        const lObject = l.key.object.name;
+        const rObject = r.key.object.name;
+        if (lObject !== rObject) {
+            return lObject < rObject ? -1 : 1;
+        }
+        const lKey = l.key.property.name;
+        const rKey = r.key.property.name;
+        return lKey === rKey ? 0 : lKey < rKey ? -1 : 1;
+    }
     else {
         const lOrder = (0, exports.getAstNodeTypeOrder)(l.key.type);
         const rOrder = (0, exports.getAstNodeTypeOrder)(r.key.type);
@@ -86,8 +104,23 @@ const makeArrayValueComparer = ({ isReversed, sourceCode }) => {
     };
     return isReversed ? (l, r) => -comparer(l, r) : comparer;
 };
+const makeEnumMemberComparer = ({ isReversed }) => {
+    const comparer = (l, r) => {
+        if (l.id.type === utils_1.AST_NODE_TYPES.Literal && r.id.type === utils_1.AST_NODE_TYPES.Literal) {
+            return compareLiterals(l.id.value, r.id.value);
+        }
+        else if (l.id.type === utils_1.AST_NODE_TYPES.Identifier && r.id.type === utils_1.AST_NODE_TYPES.Identifier) {
+            return l.id.name === r.id.name ? 0 : l.id.name < r.id.name ? -1 : 1;
+        }
+        else {
+            return (0, exports.getAstNodeTypeOrder)(l.id.type) - (0, exports.getAstNodeTypeOrder)(r.id.type);
+        }
+    };
+    return isReversed ? (l, r) => -comparer(l, r) : comparer;
+};
 exports.ComparerUtils = {
     makeObjectPropertyComparer,
     makeInterfacePropertyComparer,
     makeArrayValueComparer,
+    makeEnumMemberComparer,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-sort-annotation",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Lint rule to autofix unsorted object's keys or array",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Related PRs
* https://github.com/ronparkdev/eslint-plugin-sort-annotation/pull/9
* https://github.com/ronparkdev/eslint-plugin-sort-annotation/pull/10

@tomquist, thanks for the contribution! 